### PR TITLE
fix: python function color

### DIFF
--- a/themes/Sublime Text 4 Theme-color-theme.json
+++ b/themes/Sublime Text 4 Theme-color-theme.json
@@ -302,7 +302,10 @@
 			}
 		},
 		{
-			"scope": "entity.name.function",
+			"scope": [
+				"entity.name.function",
+				"meta.function-call.generic.python"
+			],
 			"settings": {
 				"foreground": "#5FB4B4"
 			}


### PR DESCRIPTION
## Changes
Adds the `meta.function-call.generic.python` scope to the function color scope rule.

## Tests
Tested on VS Code `1.58.2` on macOS Big Sur and confirmed that the color of function calls is now `#5FB4B4`.

## Screenshots
Before:
![Screen Shot 2021-07-22 at 5 06 21 PM](https://user-images.githubusercontent.com/1293145/126719857-3c08a6a4-796d-432e-814f-379356d3ffa4.png)

After:
![Screen Shot 2021-07-22 at 5 06 34 PM](https://user-images.githubusercontent.com/1293145/126719833-62fafeb4-f15e-4d91-8574-c8ca91df88aa.png)
